### PR TITLE
fix: GetAvailableLanguages now returns the correct list of languages when additional OCR languages have been installed directly, without adding a system language.

### DIFF
--- a/Lib/OCR.ahk
+++ b/Lib/OCR.ahk
@@ -674,19 +674,14 @@ class OCR {
      * @returns {String} 
      */
     static GetAvailableLanguages() {
-        static GlobalizationPreferencesStatics := this.CreateClass("Windows.System.UserProfile.GlobalizationPreferences", IGlobalizationPreferencesStatics := "{01BF4326-ED37-4E96-B0E9-C1340D1EA158}")
-        ComCall(9, GlobalizationPreferencesStatics, "ptr*", &LanguageList:=0)   ; get_Languages
-        ComCall(7, LanguageList, "int*", &count:=0)   ; count
+        ComCall(7, this.OcrEngineStatics, "ptr*", &LanguageList := 0)   ; AvailableRecognizerLanguages
+        ComCall(7, LanguageList, "int*", &count := 0)   ; count
         Loop count {
-            ComCall(6, LanguageList, "int", A_Index-1, "ptr*", &hString:=0)   ; get_Item
-            ComCall(6, this.LanguageFactory, "ptr", hString, "ptr*", &LanguageTest:=0)   ; CreateLanguage
-            ComCall(8, this.OcrEngineStatics, "ptr", LanguageTest, "int*", &bool:=0)   ; IsLanguageSupported
-            if (bool = 1) {
-                ComCall(6, LanguageTest, "ptr*", &hText:=0)
-                buf := DllCall("Combase.dll\WindowsGetStringRawBuffer", "ptr", hText, "uint*", &length:=0, "ptr")
-                text .= StrGet(buf, "UTF-16") "`n"
-            }
-            ObjRelease(LanguageTest)
+            ComCall(6, LanguageList, "int", A_Index - 1, "ptr*", &Language := 0)   ; get_Item
+            ComCall(6, Language, "ptr*", &hText := 0)
+            buf := DllCall("Combase.dll\WindowsGetStringRawBuffer", "ptr", hText, "uint*", &length := 0, "ptr")
+            text .= StrGet(buf, "UTF-16") "`n"
+            ObjRelease(Language)
         }
         ObjRelease(LanguageList)
         return text


### PR DESCRIPTION
The original implementation gets the list of `Languages` from the `Windows.System.UserProfile.GlobalizationPreferences` class, then checks if each language has OCR support, by calling `IsLanguageSupported` from the `Windows.Media.Ocr.OcrEngine` class. This returns an incomplete list of supported OCR languages since the user may directly install additional OCR languages without adding a system language. The new implementation fetches the list of `AvailableRecognizerLanguages` directly from the `Windows.Media.Ocr.OcrEngine` class, instead of fetching the list of languages from the `Windows.System.UserProfile.GlobalizationPreferences` class and then checking for OCR support.

# How to install an OCR language pack

The following commands install the OCR pack for "ja-JP":

```powershell
$Capability = Get-WindowsCapability -Online | Where-Object { $_.Name -Like 'Language.OCR~~~ja-JP~0.0.1.0' }
$Capability | Add-WindowsCapability -Online
```