### PR TITLE
`this.ptr` needs to exist before `NormalizeCoordinates`->`Words`->`Lines`->`get_Lines`

### DIFF
--- a/Lib/OCR.ahk
+++ b/Lib/OCR.ahk
@@ -255,6 +255,7 @@ class OCR {
 
         ComCall(6, __OCR.OcrEngine, "ptr", SoftwareBitmap, "ptr*", OcrResult:=ComValue(13,0))   ; RecognizeAsync
         __OCR.WaitForAsync(&OcrResult)
+        this.ptr := OcrResult.ptr, ObjAddRef(OcrResult.ptr)
 
         ; Cleanup
         if RandomAccessStream is __OCR.IBase
@@ -264,8 +265,6 @@ class OCR {
 
         if scale != 1
             __OCR.NormalizeCoordinates(this, scale)
-
-        this.ptr := OcrResult.ptr, ObjAddRef(OcrResult.ptr)
     }
 
     __Delete() => this.ptr ? ObjRelease(this.ptr) : 0


### PR DESCRIPTION
```ahk
Error: This value of type "OCR" has no property named "Ptr".

	286: }
	291: {
▶	292: ComCall(6, this, "ptr*", LinesList:=this.__OCR.IBase())
	293: ComCall(7, LinesList, "int*", &count:=0)
	294: lines := []
```